### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Update your Himalayas profile, add work experience and education, and set your j
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/himalayas-app-himalayas-mcp).
+
 ## Setup
 
 ### Claude Desktop


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/himalayas-app-himalayas-mcp)